### PR TITLE
Test Package Setup Fixes

### DIFF
--- a/kikoodir
+++ b/kikoodir
@@ -1,0 +1,1 @@
+magic_enum-tests

--- a/magic_enum-tests/build/root.build
+++ b/magic_enum-tests/build/root.build
@@ -10,3 +10,6 @@ cxx{*}: extension = cpp
 # The test target for cross-testing (running tests under Wine, etc).
 #
 test.target = $cxx.target
+
+exe{*}: test=true # All executables in this package are tests.
+

--- a/magic_enum-tests/tests/test
+++ b/magic_enum-tests/tests/test
@@ -1,1 +1,0 @@
-/home/wmbat/projects/build2_ports/magic_enum-gcc-release/magic_enum-test/tests/test

--- a/magic_enum-tests/tests/test_flags
+++ b/magic_enum-tests/tests/test_flags
@@ -1,1 +1,0 @@
-/home/wmbat/projects/build2_ports/magic_enum-gcc-release/magic_enum-test/tests/test_flags

--- a/magic_enum-tests/tests/tests_src
+++ b/magic_enum-tests/tests/tests_src
@@ -1,1 +1,1 @@
-../../upstream/test/
+../../upstream/test

--- a/magic_enum/magic_enum/include
+++ b/magic_enum/magic_enum/include
@@ -1,1 +1,1 @@
-../../upstream/include/
+../../upstream/include

--- a/magic_enum/manifest
+++ b/magic_enum/manifest
@@ -14,3 +14,5 @@ requires: c++ >= 17
 
 depends: * build2 >= 0.13.0
 depends: * bpkg >= 0.13.0
+
+tests: magic_enum-tests == $


### PR DESCRIPTION
- The symlinks were buggy on Windows, fixed it by re-creating them on Windows with[ `export MSYS=winsymlinks:nativestrict`](https://anonsage.com/dev/2020-03-27-til-windows-git-bash-symbolic-link/) but it should also have worked if created initially on Linux.
- Fixed: The tests executable were not marked as tests.
- Fixed: the test package was not specified as such in the library package (otherwise bdep/bpkg can't guess that the test package is a test package for that library package);
- Removed tests binaries.
