### PR TITLE
Fixes test package not providing manifest information

### DIFF
--- a/magic_enum-tests/build/bootstrap.build
+++ b/magic_enum-tests/build/bootstrap.build
@@ -3,3 +3,4 @@ project = magic_enum-tests
 using config
 using test
 using dist
+using version

--- a/magic_enum-tests/build/bootstrap.build
+++ b/magic_enum-tests/build/bootstrap.build
@@ -1,4 +1,4 @@
-project = # Unnamed tests subproject.
+project = magic_enum-tests
 
 using config
 using test

--- a/magic_enum-tests/manifest
+++ b/magic_enum-tests/manifest
@@ -1,5 +1,5 @@
 : 1
-name: magic_enum-test
+name: magic_enum-tests
 version: 0.7.3
 summary: unit tests for the magic_enum library
 license: MIT License


### PR DESCRIPTION
- added missing project name
- added usage of the `version` build-system module so that the manifest can be read and used by `b`

`bdep ci`: https://ci.stage.build2.org/@1f5dfdf6-7738-4abc-a8fc-a629f4378e87
